### PR TITLE
3 adding endpoint called user role

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -54,6 +54,10 @@ class UserUpdate(UserBase):
             raise ValueError("At least one field must be provided for update")
         return values
 
+class RoleUpdate(UserBase):
+    email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
+    role: Optional[str] = Field(None, example="AUTHENTICATED")
+
 class UserResponse(UserBase):
     id: uuid.UUID = Field(..., example=uuid.uuid4())
     email: EmailStr = Field(..., example="john.doe@example.com")


### PR DESCRIPTION
The user-role endpoint allows administrators and managers to update a user's role by their user ID. The update_role method validates the update data using the RoleUpdate schema and updates the user role in the database. Proper error handling and logging are implemented to ensure data integrity and provide debugging information. This endpoint helps in efficient user role management while maintaining security and validation standards.